### PR TITLE
[TASK] Make the raven client in the ErrorHandler accessible

### DIFF
--- a/Classes/Networkteam/SentryClient/ErrorHandler.php
+++ b/Classes/Networkteam/SentryClient/ErrorHandler.php
@@ -104,4 +104,11 @@ class ErrorHandler {
 	public function injectSettings(array $settings) {
 		$this->dsn = isset($settings['dsn']) ? $settings['dsn']: '';
 	}
+
+	/**
+	 * @return \Raven_Client
+	 */
+	public function getClient() {
+		return $this->client;
+	}
 }


### PR DESCRIPTION
To be able to leverage all functionality from the raven client, the client
is accessible from the ErrorHandler.