### PR TITLE
TASK: Adjust exception handling for compatibility with PHP 7

### DIFF
--- a/Classes/Networkteam/SentryClient/Handler/DebugExceptionHandler.php
+++ b/Classes/Networkteam/SentryClient/Handler/DebugExceptionHandler.php
@@ -10,7 +10,7 @@ class DebugExceptionHandler extends \TYPO3\Flow\Error\DebugExceptionHandler {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function echoExceptionWeb(\Exception $exception) {
+	public function echoExceptionWeb($exception) {
 		$this->sendExceptionToSentry($exception);
 		parent::echoExceptionWeb($exception);
 	}
@@ -18,7 +18,7 @@ class DebugExceptionHandler extends \TYPO3\Flow\Error\DebugExceptionHandler {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function echoExceptionCLI(\Exception $exception) {
+	public function echoExceptionCLI($exception) {
 		$this->sendExceptionToSentry($exception);
 		parent::echoExceptionCLI($exception);
 	}
@@ -29,9 +29,9 @@ class DebugExceptionHandler extends \TYPO3\Flow\Error\DebugExceptionHandler {
 	 * During compiletime there might be missing dependencies, so we need additional safeguards to
 	 * not cause errors.
 	 *
-	 * @param \Exception $exception
+	 * @param \Exception $exception \Exception or \Throwable
 	 */
-	protected function sendExceptionToSentry(\Exception $exception) {
+	protected function sendExceptionToSentry($exception) {
 		if (!Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
 			return;
 		}

--- a/Classes/Networkteam/SentryClient/Handler/ProductionExceptionHandler.php
+++ b/Classes/Networkteam/SentryClient/Handler/ProductionExceptionHandler.php
@@ -10,7 +10,7 @@ class ProductionExceptionHandler extends \TYPO3\Flow\Error\ProductionExceptionHa
 	/**
 	 * {@inheritdoc}
 	 */
-	public function echoExceptionWeb(\Exception $exception) {
+	public function echoExceptionWeb($exception) {
 		$this->sendExceptionToSentry($exception);
 		parent::echoExceptionWeb($exception);
 	}
@@ -18,7 +18,7 @@ class ProductionExceptionHandler extends \TYPO3\Flow\Error\ProductionExceptionHa
 	/**
 	 * {@inheritdoc}
 	 */
-	public function echoExceptionCLI(\Exception $exception) {
+	public function echoExceptionCLI($exception) {
 		$this->sendExceptionToSentry($exception);
 		parent::echoExceptionCLI($exception);
 	}
@@ -29,9 +29,9 @@ class ProductionExceptionHandler extends \TYPO3\Flow\Error\ProductionExceptionHa
 	 * During compiletime there might be missing dependencies, so we need additional safeguards to
 	 * not cause errors.
 	 *
-	 * @param \Exception $exception
+	 * @param \Exception $exception \Exception or \Throwable
 	 */
-	protected function sendExceptionToSentry(\Exception $exception) {
+	protected function sendExceptionToSentry($exception) {
 		if (!Bootstrap::$staticObjectManager instanceof ObjectManagerInterface) {
 			return;
 		}


### PR DESCRIPTION
This change adapt to support change in recent version of Flow 2.0 and 2.1
to support PHP 7 (see: https://github.com/neos/flow-development-collection/pull/143)