### PR TITLE
Use sentry/sentry package instead of outdated raven/raven; update interface

### DIFF
--- a/Classes/Networkteam/SentryClient/ErrorHandler.php
+++ b/Classes/Networkteam/SentryClient/ErrorHandler.php
@@ -61,7 +61,11 @@ class ErrorHandler {
 			$extraData['referenceCode'] = $exception->getReferenceCode();
 		}
 
-		$this->client->captureException($exception, array('extra' => $extraData, 'tags' => $tags));
+		$this->client->captureException($exception, array(
+				'message' => $exception->getMessage(),
+				'extra' => $extraData,
+				'tags' => $tags)
+		);
 	}
 
 	/**

--- a/Classes/Networkteam/SentryClient/Package.php
+++ b/Classes/Networkteam/SentryClient/Package.php
@@ -9,7 +9,7 @@ class Package extends BasePackage {
 	 * {@inheritdoc}
 	 */
 	public function boot(\TYPO3\Flow\Core\Bootstrap $bootstrap) {
-		require_once(FLOW_PATH_PACKAGES . '/Libraries/raven/raven/lib/Raven/Autoloader.php');
+		require_once(FLOW_PATH_PACKAGES . '/Libraries/sentry/sentry/lib/Raven/Autoloader.php');
 		\Raven_Autoloader::register();
 
 		$bootstrap->getSignalSlotDispatcher()->connect('TYPO3\Flow\Core\Booting\Sequence', 'afterInvokeStep', function($step, $runlevel) use($bootstrap) {

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ adding the following exclude configuration to your settings:
         object:
           excludeClasses:
             'Networkteam.SentryClient': ['Networkteam\\SentryClient\\Aspect\\TypoScriptHandlerAspect']
+            
+For Flow Versions not ignoring external Packages by default (< 3.0.0) you also need to exclude the following packages from being reflected:
+
+    'monolog.monolog': ['.*']
+    'sentry.sentry': ['.*']            
 
 Usage:
 ------

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "A sentry client for Flow and Neos",
     "require": {
         "typo3/flow": ">=2.3.9 <=2.3.12 || >=3.0.3",
-        "raven/raven": "0.11.*"
+        "sentry/sentry": "^1.2"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I reworked the deps to the newer sentry-php repo, since raven/raven is abandoned. Had to tweak the Exception creation a little to make it work again.