### PR TITLE
[TASK] Refactor package to be decoupled from TYPO3.Party Package

### DIFF
--- a/Classes/Networkteam/SentryClient/Context/DummyUserContext.php
+++ b/Classes/Networkteam/SentryClient/Context/DummyUserContext.php
@@ -1,0 +1,19 @@
+<?php
+namespace Networkteam\SentryClient\Context;
+
+/***************************************************************
+ *  (c) 2016 networkteam GmbH - all rights reserved
+ ***************************************************************/
+
+class DummyUserContext implements UserContextServiceInterface {
+
+	/**
+	 * Returns ContextData to be added to the sentry entry
+	 *
+	 * @param \TYPO3\Flow\Security\Context $securityContext
+	 * @return array
+	 */
+	public function getUserContext(\TYPO3\Flow\Security\Context $securityContext) {
+		return array();
+	}
+}

--- a/Classes/Networkteam/SentryClient/Context/PartyUserContext.php
+++ b/Classes/Networkteam/SentryClient/Context/PartyUserContext.php
@@ -1,0 +1,29 @@
+<?php
+namespace Networkteam\SentryClient\Context;
+
+/***************************************************************
+ *  (c) 2016 networkteam GmbH - all rights reserved
+ ***************************************************************/
+
+use TYPO3\Party\Domain\Model\Person;
+
+class PartyUserContext implements UserContextServiceInterface {
+
+	/**
+	 * Returns ContextData to be added to the sentry entry
+	 *
+	 * @param \TYPO3\Flow\Security\Context $securityContext
+	 * @return array
+	 */
+	public function getUserContext(\TYPO3\Flow\Security\Context $securityContext) {
+		$party = $securityContext->getParty();
+		$userContext = [];
+		if ($party instanceof Person && $party->getPrimaryElectronicAddress() !== NULL) {
+			$userContext['email'] = (string)$party->getPrimaryElectronicAddress();
+		} elseif ($party !== NULL && \TYPO3\Flow\Reflection\ObjectAccess::isPropertyGettable($party, 'emailAddress')) {
+			$userContext['email'] = (string)\TYPO3\Flow\Reflection\ObjectAccess::getProperty($party, 'emailAddress');
+		}
+
+		return $userContext;
+	}
+}

--- a/Classes/Networkteam/SentryClient/Context/UserContextServiceInterface.php
+++ b/Classes/Networkteam/SentryClient/Context/UserContextServiceInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace Networkteam\SentryClient\Context;
+
+/***************************************************************
+ *  (c) 2016 networkteam GmbH - all rights reserved
+ ***************************************************************/
+
+interface UserContextServiceInterface {
+
+	/**
+	 * Returns ContextData to be added to the sentry entry
+	 *
+	 * @param \TYPO3\Flow\Security\Context $securityContext
+	 * @return array
+	 */
+	public function getUserContext(\TYPO3\Flow\Security\Context $securityContext);
+}

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,0 +1,3 @@
+Networkteam\SentryClient\Context\UserContextServiceInterface:
+  scope: singleton
+  className: Networkteam\SentryClient\Context\PartyUserContext

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ adding the following exclude configuration to your settings:
           excludeClasses:
             'Networkteam.SentryClient': ['Networkteam\\SentryClient\\Aspect\\TypoScriptHandlerAspect']
 
+Additionally if you do not use the TYPO3.Party Package in your Flow Application you need to exclude the following class too
+     
+     \Networkteam\SentryClient\User\PartyUserContext
+
+You can implement the `\Networkteam\SentryClient\User\UserContextServiceInterface` to pass your own user context 
+information to the logging. If you do not have the TYPO3.Party Package and don't want to implement your own 
+`UserContextService` you need to set the `\Networkteam\SentryClient\User\DummyUserContext` in the Objects.yaml like
+
+    Networkteam\SentryClient\User\UserContextServiceInterface:
+      className: Networkteam\SentryClient\User\DummyUserContext
+
+This will prevent any collection of user information except information that is available via the Flow SecurityContext.
+
 Usage:
 ------
 


### PR DESCRIPTION
Removed hard dependency on TYPO3.Party by creating a
UserContextServiceInterface, a service implementing this interface
can add additional information to the context data given to the
sentry client.

This refactoring is needed to stay compatible with the current
Flow development.

There is no BC break as the current configuration has the same
behaviour like the last versions