### PR TITLE
TASK: Remove deprecated Setting Neos.Flow.object.excludeClasses

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -7,9 +7,3 @@ Neos:
     error:
       exceptionHandler:
         className: Networkteam\SentryClient\Handler\ProductionExceptionHandler
-    object:
-      excludeClasses:
-        monolog.monolog:
-          - '.*'
-        sentry.sentry:
-          - '.*'


### PR DESCRIPTION
It was deprecated in Flow 3.0 and now shows an error in /neos/administration/configuration