### PR TITLE
Improve false positives by better filtering

### DIFF
--- a/Classes/Networkteam/SentryClient/Aspect/FusionHandlerAspect.php
+++ b/Classes/Networkteam/SentryClient/Aspect/FusionHandlerAspect.php
@@ -2,6 +2,7 @@
 namespace Networkteam\SentryClient\Aspect;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Fusion\Core\ExceptionHandlers\AbsorbingHandler;
 
 /**
  * @Flow\Aspect
@@ -15,12 +16,17 @@ class FusionHandlerAspect {
 	protected $errorHandler;
 
 	/**
-	 * Forward all exceptions that are handled in TypoScript rendering exception handlers to Sentry
+	 * Forward all exceptions that are handled in Fusion rendering exception handlers to Sentry
+	 *
+	 * Ignores the exception, if it was handled by an AbsorbingHandler.
 	 *
 	 * @Flow\After("within(Neos\Fusion\Core\ExceptionHandlers\AbstractRenderingExceptionHandler) && method(.*->handle())")
 	 * @param \Neos\Flow\Aop\JoinPointInterface $joinPoint
 	 */
 	public function captureException(\Neos\Flow\Aop\JoinPointInterface $joinPoint) {
+		if ($joinPoint->getProxy() instanceof AbsorbingHandler) {
+			return;
+		}
 		$exception = $joinPoint->getMethodArgument('exception');
 		$args = $joinPoint->getMethodArguments();
 		$fusionPath = isset($args['fusionPath']) ? $args['fusionPath'] : $args['typoScriptPath'];

--- a/Classes/Networkteam/SentryClient/Handler/DebugExceptionHandler.php
+++ b/Classes/Networkteam/SentryClient/Handler/DebugExceptionHandler.php
@@ -37,7 +37,9 @@ class DebugExceptionHandler extends \Neos\Flow\Error\DebugExceptionHandler {
 		}
 
 		$options = $this->resolveCustomRenderingOptions($exception);
-		if (isset($options['logException']) && $options['logException']) {
+		$logException = isset($options['logException']) && $options['logException'];
+		$sentryClientIgnoreException = isset($options['sentryClientIgnoreException']) && $options['sentryClientIgnoreException'];
+		if ($logException && !$sentryClientIgnoreException) {
 			try {
 				$errorHandler = Bootstrap::$staticObjectManager->get('Networkteam\SentryClient\ErrorHandler');
 				if ($errorHandler !== NULL) {

--- a/Classes/Networkteam/SentryClient/Handler/ProductionExceptionHandler.php
+++ b/Classes/Networkteam/SentryClient/Handler/ProductionExceptionHandler.php
@@ -37,7 +37,9 @@ class ProductionExceptionHandler extends \Neos\Flow\Error\ProductionExceptionHan
 		}
 
 		$options = $this->resolveCustomRenderingOptions($exception);
-		if (isset($options['logException']) && $options['logException']) {
+		$logException = isset($options['logException']) && $options['logException'];
+		$sentryClientIgnoreException = isset($options['sentryClientIgnoreException']) && $options['sentryClientIgnoreException'];
+		if ($logException && !$sentryClientIgnoreException) {
 			try {
 				/** @var \Networkteam\SentryClient\ErrorHandler $errorHandler */
 				$errorHandler = Bootstrap::$staticObjectManager->get('Networkteam\SentryClient\ErrorHandler');

--- a/Configuration/Development/Settings.yaml
+++ b/Configuration/Development/Settings.yaml
@@ -1,4 +1,3 @@
-
 Neos:
   Flow:
     error:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,9 +1,36 @@
-
 Networkteam:
   SentryClient:
+
+    #
+    # Sentry DSN
+    #
+    # The DSN can be found in Sentry by navigating to [Project Name] -> Project Settings -> Client Keys (DSN).
+    #
     dsn: ''
+
 Neos:
   Flow:
+
     error:
+
       exceptionHandler:
+
         className: Networkteam\SentryClient\Handler\ProductionExceptionHandler
+
+        defaultRenderingOptions:
+          #
+          # Exceptions can be ignored for Sentry, but still be logged locally with "logException"
+          #
+          sentryClientIgnoreException: FALSE
+
+        renderingGroups:
+
+          authenticationRequiredExceptions:
+            matchingStatusCodes: [401]
+            options:
+              sentryClientIgnoreException: TRUE
+
+          accessDeniedExceptions:
+            matchingStatusCodes: [403]
+            options:
+              sentryClientIgnoreException: TRUE


### PR DESCRIPTION
Check if an exception was absorbed in Fusion (e.g. Asset could not be
rendered) and add a new configuration option
`sentryClientIgnoreException` to ignore exceptions for Sentry while
still logging them to an exception log. Configure this by default for
exceptions with 401 and 403 status codes.