### PR TITLE
FEATURE: Allow installation with sentry/sdk ^3.0

### DIFF
--- a/Classes/ErrorHandler.php
+++ b/Classes/ErrorHandler.php
@@ -7,10 +7,10 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Core\Bootstrap;
 use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Utility\Environment;
+use Sentry\SentrySdk;
 use function Sentry\captureException;
 use function Sentry\configureScope;
 use function Sentry\init as initSentry;
-use Sentry\State\Hub;
 use Sentry\State\Scope;
 
 /**
@@ -168,7 +168,7 @@ class ErrorHandler
      */
     protected function setReleaseContext(): void
     {
-        $client = Hub::getCurrent()->getClient();
+        $client = SentrySdk::getCurrentHub()->getClient();
         if ($this->release !== '' && $client) {
             $options = $client->getOptions();
             $options->setRelease($this->release);

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": "~7.1",
         "neos/flow": ">=5.0.0",
-        "sentry/sdk": "^2.0",
+        "sentry/sdk": "^2.2 || ^3.0",
         "jenssegers/agent": "^2.6"
     },
     "autoload": {


### PR DESCRIPTION
This allows the usage together with `sentry/sdk` 3.0+.

The only problem I encountered was the removed `Hub::getCurrent()`. It is deprecated since `sentry/sdk` 2.2 and `SentrySdk::getCurrentHub()` should be used instead.