### PR TITLE
Bugfix: Do not report exceptions twice

### DIFF
--- a/Classes/ErrorHandler.php
+++ b/Classes/ErrorHandler.php
@@ -45,7 +45,19 @@ class ErrorHandler
      */
     public function initializeObject()
     {
-        initSentry(['dsn' => $this->dsn]);
+        initSentry([
+            'dsn' => $this->dsn,
+            'integrations' => static function (array $integrations) {
+                $integrations = array_filter($integrations, static function (\Sentry\Integration\IntegrationInterface $integration) {
+                    // Prevent reporting exceptions twice
+                    if ($integration instanceof \Sentry\Integration\ExceptionListenerIntegration) {
+                        return false;
+                    }
+                    return true;
+                });
+                return $integrations;
+            },
+        ]);
         $this->agent = new Agent();
     }
 


### PR DESCRIPTION
When initialising Sentry it registers a 'second' exception handler which
is called first and then returns the exception to the previous exception
handler 'our handler' which does the cool stuff.