### PR TITLE
Ignore Bad Request Exceptions

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -39,3 +39,8 @@ Neos:
             matchingStatusCodes: [403]
             options:
               sentryClientIgnoreException: true
+
+          badRequestExceptions:
+            matchingStatusCodes: [400]
+            options:
+              sentryClientIgnoreException: true


### PR DESCRIPTION
This message occurs, when when a client submits a form with invalid form data:

"A hashed string must contain at least 40 characters, the given string was only 2 characters long."

Since https://github.com/neos/flow-development-collection/pull/3234 the Exception leads to a HTTP 400 response.